### PR TITLE
Changes the colors to resemble the Visual Studio Code Extension. 

### DIFF
--- a/grammars/denizenscript.cson
+++ b/grammars/denizenscript.cson
@@ -42,7 +42,7 @@ repository:
                 end: '\\s'
                 beginCaptures:
                   1:
-                    name: 'entity.name.tag.denizenscript'
+                    name: 'markup.heading.key.denizenscript'
                   2:
                     name: 'operator.colon.denizenscript'
             }
@@ -50,12 +50,12 @@ repository:
     commands:
         patterns: [
             {
-                begin: '(-)\\s([^\\s]+)'
+                begin: '(-)\\s([^\\s\\[]+)'
                 captures:
                     1:
                       name: 'operator.dash.denizenscript'
                     2:
-                      name: 'keyword.command.denizenscript'
+                      name: 'entity.other.command.denizenscript'
                 end: '\\s'
             }
         ]
@@ -93,9 +93,9 @@ repository:
             }
         ]
     tag_brackets:
-        begin: '\\['
+        begin: '(?<=\\w|<)\\['
         end: '\\]'
-        name: 'keyword.tag-brackets.denizenscript'
+        name: 'entity.name.tag.tag-brackets.denizenscript'
         patterns: [
             {
                 include: '#tags'

--- a/grammars/denizenscript.cson
+++ b/grammars/denizenscript.cson
@@ -23,7 +23,7 @@ patterns: [
         include: '#tags'
     }
     {
-        include: '#tag_brackets'
+        include: '#tag_params'
     }
 ]
 repository:
@@ -68,7 +68,7 @@ repository:
                 include: '#tags'
             }
             {
-                include: '#tag_brackets'
+                include: '#tag_params'
             }
         ]
     single_quotes:
@@ -80,7 +80,7 @@ repository:
                 include: '#tags'
             }
             {
-                include: '#tag_brackets'
+                include: '#tag_params'
             }
         ]
     tags:
@@ -89,10 +89,10 @@ repository:
         name: 'constant.language.tag.denizenscript'
         patterns: [
             {
-                include: '#tag_brackets'
+                include: '#tag_params'
             }
         ]
-    tag_brackets:
+    tag_params:
         begin: '(?<=\\w|<)\\['
         end: '\\]'
         name: 'entity.name.tag.tag-brackets.denizenscript'

--- a/grammars/denizenscript.cson
+++ b/grammars/denizenscript.cson
@@ -28,37 +28,33 @@ patterns: [
 ]
 repository:
     comments:
-        patterns: [
-            {
-                begin: '^\\s*#.*$'
-                end: '\\n'
-                name: 'comment.normal.denizenscript'
-            }
-        ]
+        begin: '(^\\s*#.+[TODO].*)|(^\\s*#.*[\\@\\\+=#_\\/|].*)|(^\\s*#.*[-].*)|(^\\s*#.*)'
+        end: '\\n'
+        beginCaptures:
+            1:
+                name: 'variable.parameter.todo-comment.denizenscript'
+            2:
+                name: 'keyword.header-comment.denizenscript'
+            3:
+                name: 'comment.line.number-sign.denizenscript'
+            4:
+                name: 'comment.line.number-sign.denizenscript'
     keys:
-        patterns: [
-            {
-                begin: '(^[^-#\\n]*)(:)'
-                end: '\\s'
-                beginCaptures:
-                  1:
-                    name: 'markup.heading.key.denizenscript'
-                  2:
-                    name: 'operator.colon.denizenscript'
-            }
-        ]
+        begin: '(^[^-#\\n]*)(:)'
+        end: '\\s'
+        beginCaptures:
+            1:
+                name: 'markup.heading.key.denizenscript'
+            2:
+                name: 'operator.colon.denizenscript'
     commands:
-        patterns: [
-            {
-                begin: '(-)\\s([^\\s\\[]+)'
-                captures:
-                    1:
-                      name: 'operator.dash.denizenscript'
-                    2:
-                      name: 'entity.other.command.denizenscript'
-                end: '\\s'
-            }
-        ]
+        begin: '(-)\\s([^\\s\\[]+)'
+        captures:
+            1:
+                name: 'operator.dash.denizenscript'
+            2:
+                name: 'entity.other.command.denizenscript'
+        end: '\\s'
     double_quotes:
         begin: '"'
         end: '\\n|"'

--- a/grammars/denizenscript.cson
+++ b/grammars/denizenscript.cson
@@ -8,6 +8,12 @@ patterns: [
         include: '#comments'
     }
     {
+        include: '#todo_comments'
+    }
+    {
+        include: '#header_comments'
+    }
+    {
         include: '#keys'
     }
     {
@@ -28,17 +34,17 @@ patterns: [
 ]
 repository:
     comments:
-        begin: '(^\\s*#.+[TODO].*)|(^\\s*#.*[\\@\\\+=#_\\/|].*)|(^\\s*#.*[-].*)|(^\\s*#.*)'
+        begin: '^\\s*#(?!\\s*todo|\\s*TODO|(?:\\s*(?:\\||\\+|=|#|_|@|\\/)))'
         end: '\\n'
-        beginCaptures:
-            1:
-                name: 'variable.parameter.todo-comment.denizenscript'
-            2:
-                name: 'keyword.header-comment.denizenscript'
-            3:
-                name: 'comment.line.number-sign.denizenscript'
-            4:
-                name: 'comment.line.number-sign.denizenscript'
+        name: 'comment.line.number-sign.denizenscript'
+    todo_comments:
+        begin: '^\\s*#\\s*(?:TODO|todo)'
+        end: '\\n'
+        name: 'variable.todo-comment.denizenscript'
+    header_comments:
+        begin: '^\\s*#\\s*(?:\\||\\+|=|#|_|@|\\/)'
+        end: '\\n'
+        name: 'keyword.header-comment.denizenscript'
     keys:
         begin: '(^[^-#\\n]*)(:)'
         end: '\\s'


### PR DESCRIPTION
# Changes:

- ### Changed colors:

![Color Changes](https://media.discordapp.net/attachments/477340871927398400/949697876861255811/highlight_new_showcase.png?width=782&height=671)

- ### Added TODO and header comments:
![TODO comment](https://user-images.githubusercontent.com/63469489/158482265-5c4a6b77-bca0-45b5-91b0-b43e00801905.png)
![Header comment](https://user-images.githubusercontent.com/63469489/158482365-9259d01f-c61f-4873-96be-59b8e98c0956.png)

- ### Changed name of repository key.
Went from being `tag_brackets` to the more fitting: `tag_params`.

- ### Fixed standalone single quote coloring rest of line as a string.
- ### Changed coloring of `[]` inside of inventory containers to now be colored the same as normal text and to not be captured as a command.
