### PR TITLE
Command and key highlight conflict

### DIFF
--- a/grammars/denizenscript.cson
+++ b/grammars/denizenscript.cson
@@ -59,7 +59,7 @@ repository:
     keys:
         # key:
         # key: value
-        begin: '(?i)(^(?!.*- |#|\\n|.*(?:interact scripts|default constants|data|constants|text|lore|aliases|slots|enchantments|input)(?=(?::))).*?)(?=(:)\\s)'
+        begin: '(?i)(^(?!^\\s*-|#|\\n|.*(?:interact scripts|default constants|data|constants|text|lore|aliases|slots|enchantments|input)(?=(?::))).*?)(?=(:)\\s)'
         end: '\\s'
         beginCaptures:
             1:
@@ -77,7 +77,7 @@ repository:
         end: '^(?!.*- |\\n|\\s*#)'
         beginCaptures:
             1:
-                name: 'markup.heading.key.denizenscript'
+                name: 'markup.heading.not_script_key.denizenscript'
             2:
                 name: 'operator.colon.denizenscript'
         patterns: [
@@ -101,7 +101,7 @@ repository:
         # - narrate "Hello there! You look amazing today! <3"
         # - flag <player> looking_amazing
         # - define who_looks_amazing <player>
-        begin: '^\\s.*(-)\\s([^\\s<>"\']+)'
+        begin: '^\\s*(-)\\s([^\\s<>"\']+)'
         end: '\\s'
         captures:
             1:

--- a/grammars/denizenscript.cson
+++ b/grammars/denizenscript.cson
@@ -101,7 +101,7 @@ repository:
         # - narrate "Hello there! You look amazing today! <3"
         # - flag <player> looking_amazing
         # - define who_looks_amazing <player>
-        begin: '(-)\\s([^\\s<>"\']+)'
+        begin: '^\\s.*(-)\\s([^\\s<>"\']+)'
         end: '\\s'
         captures:
             1:


### PR DESCRIPTION
- [Commands only match if - is the first non-whitespace character.](https://github.com/DenizenScript/denizenscript-grammar/commit/b6f699aee36e611d379acb021b832edcdfa6e3ae)
- [Keys can now include - within their values and not freak out.](https://github.com/DenizenScript/denizenscript-grammar/commit/8bd07ee2aeafece7d2aa9704ff9765be738ebe90)